### PR TITLE
add linux build script and fix minor platform-independence issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vs
 *.exe
 *.pdb
+cultivation
 build/

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ "$1" == "-d" ]; then
+	DEBUGFLAGS="-O0 -g -rdynamic"
+fi
+
+OUT="cultivation"
+SRC="src/main.c"
+CFLAGS="-Wall -std=c2x"
+LDFLAGS="-lm -ldl"
+
+cc -o $OUT $CFLAGS $LDFLAGS $DEBUGFLAGS $SRC $(pkg-config --cflags --libs sdl2 SDL2_ttf SDL2_image)

--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#include <math.h>
 
 typedef uint8_t u8;
 typedef uint32_t u32;
@@ -562,7 +563,7 @@ int main(int argc, char *args[]) {
   init();
 
   SDL_Window *window =
-      SDL_CreateWindow("Cultivation Sim", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_SHOWN);
+      SDL_CreateWindow("Cultivation Sim", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_SHOWN|SDL_WINDOW_RESIZABLE);
   if (!window) {
     fprintf(stderr, "could not create window: %s\n", SDL_GetError());
     return 1;


### PR DESCRIPTION
- call SDL_CreateWindow with SDL_WINDOW_RESIZEABLE, as some xorg window managers break without it.
- explicitly include <math.h>, instead of assuming that windows stdio.h will include it